### PR TITLE
add a circleci user to avoid home directory issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,8 @@ RUN apk add alpine-sdk -t build && \
   gem install engineyard -v '3.2.5' && \
   apk del build
 
+RUN adduser -D circleci
+
+USER circleci
+
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
We started getting a failed setup step on our builds ([example](https://circleci.com/gh/4ormat/4ormat/166350)) where the cache restoration step was attempting to untar the cache into `/root`, but the circleci image runs as the user `circleci` and doesn't have access to write to `/root`.

The cause of this issue is in [#8511](https://github.com/4ormat/4ormat/pull/8511) which switches the image for certain build steps to `4ormat/ey-image`. This image's default is `root`. In our `circleci.yml` we use a dynamic path (`~/4ormat`) which resolves to a different absolute path depending on the image being run. So when `4ormat/ey-image` is used for the `save_caches` step, the code is located in `/root/4ormat` when it's saved. Circle's cache restore action always restores files to the same absolute path they came from, so this causes a problem when it's restored back to the circleci image.

To fix, we can:
1. Change all the working paths in our circleci.yml to not include a `~` reference, or
2. Make sure all the images in the build use the same username with the same home directory path.

I've chosen to do #2 here